### PR TITLE
Fix Linux regression in 0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
       dist: xenial
       services: docker
       env: DOCKER_IMAGE=swift:4.1.3 SWIFT_SNAPSHOT=4.1.3
+    - os: linux
+      dist: trusty
 
 script:
   - swift test

--- a/Sources/AnyCodable/AnyEncodable.swift
+++ b/Sources/AnyCodable/AnyEncodable.swift
@@ -48,8 +48,10 @@ extension _AnyEncodable {
         var container = encoder.singleValueContainer()
 
         switch value {
+            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let number as NSNumber:
             try encode(nsnumber: number, into: &container)
+            #endif
         case is NSNull, is Void:
             try container.encodeNil()
         case let bool as Bool:
@@ -94,6 +96,7 @@ extension _AnyEncodable {
         }
     }
 
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
     private func encode(nsnumber: NSNumber, into container: inout SingleValueEncodingContainer) throws {
         switch CFNumberGetType(nsnumber) {
         case .charType:
@@ -124,6 +127,7 @@ extension _AnyEncodable {
         #endif
         }
     }
+    #endif
 }
 
 extension AnyEncodable: Equatable {


### PR DESCRIPTION
According to #18, use of `CFNumberGetType` is causing problems on Linux. This PR attempts to solve this by adding conditional compilation blocks to only use this on Apple platforms. 