### PR TITLE
Use more strict types

### DIFF
--- a/Sources/AnyCodable/AnyDecodable.swift
+++ b/Sources/AnyCodable/AnyDecodable.swift
@@ -26,7 +26,7 @@ import Foundation
      """.data(using: .utf8)!
 
      let decoder = JSONDecoder()
-     let dictionary = try! decoder.decode([String: AnyCodable].self, from: json)
+     let dictionary = try! decoder.decode([String: AnyDecodable].self, from: json)
  */
 public struct AnyDecodable: Decodable {
     public let value: Any
@@ -67,12 +67,12 @@ extension _AnyDecodable {
             self.init(double)
         } else if let string = try? container.decode(String.self) {
             self.init(string)
-        } else if let array = try? container.decode([AnyCodable].self) {
+        } else if let array = try? container.decode([AnyDecodable].self) {
             self.init(array.map { $0.value })
-        } else if let dictionary = try? container.decode([String: AnyCodable].self) {
+        } else if let dictionary = try? container.decode([String: AnyDecodable].self) {
             self.init(dictionary.mapValues { $0.value })
         } else {
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "AnyCodable value cannot be decoded")
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "AnyDecodable value cannot be decoded")
         }
     }
 }

--- a/Sources/AnyCodable/AnyEncodable.swift
+++ b/Sources/AnyCodable/AnyEncodable.swift
@@ -95,11 +95,11 @@ extension _AnyEncodable {
         case let url as URL:
             try container.encode(url)
         case let array as [Any?]:
-            try container.encode(array.map { AnyCodable($0) })
+            try container.encode(array.map { AnyEncodable($0) })
         case let dictionary as [String: Any?]:
-            try container.encode(dictionary.mapValues { AnyCodable($0) })
+            try container.encode(dictionary.mapValues { AnyEncodable($0) })
         default:
-            let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "AnyCodable value cannot be encoded")
+            let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "AnyEncodable value cannot be encoded")
             throw EncodingError.invalidValue(value, context)
         }
     }

--- a/Tests/AnyCodableTests/AnyEncodableTests.swift
+++ b/Tests/AnyCodableTests/AnyEncodableTests.swift
@@ -49,7 +49,7 @@ class AnyEncodableTests: XCTestCase {
 
         let encoder = JSONEncoder()
 
-        let json = try encoder.encode(AnyCodable(dictionary))
+        let json = try encoder.encode(AnyEncodable(dictionary))
         let encodedJSONObject = try JSONSerialization.jsonObject(with: json, options: []) as! NSDictionary
 
         let expected = """


### PR DESCRIPTION
As a whole, I don't think there's anything wrong in practice but this way makes a bit more sense.

I just wanted to use `AnyDecodable` and copied `AnyDecodable.swift` but it didn't work. Hence this PR.