### PR TITLE
Unset static_framework attribute in podspec 

### DIFF
--- a/AnyCodable-FlightSchool.podspec
+++ b/AnyCodable-FlightSchool.podspec
@@ -28,5 +28,4 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/**/*.swift'
 
   s.swift_version = '5.0'
-  # s.static_framework = true
 end

--- a/AnyCodable-FlightSchool.podspec
+++ b/AnyCodable-FlightSchool.podspec
@@ -28,5 +28,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/**/*.swift'
 
   s.swift_version = '5.0'
-  s.static_framework = true
+  # s.static_framework = true
 end


### PR DESCRIPTION
This is to address errors of the form: 

"The 'Pods-App' target has transitive dependencies that include static frameworks"

Discussion of the issue (different project, not AnyCodable): https://stackoverflow.com/questions/39871214/the-pods-app-target-has-transitive-dependencies-that-include-static-binaries-w