### PR TITLE
Avoid using Foundation when it is unavailable

### DIFF
--- a/Sources/AnyCodable/AnyCodable.swift
+++ b/Sources/AnyCodable/AnyCodable.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /**
  A type-erased `Codable` value.
 

--- a/Sources/AnyCodable/AnyDecodable.swift
+++ b/Sources/AnyCodable/AnyDecodable.swift
@@ -1,4 +1,6 @@
+#if canImport(Foundation)
 import Foundation
+#endif
 
 /**
  A type-erased `Decodable` value.
@@ -56,7 +58,11 @@ extension _AnyDecodable {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
-            self.init(NSNull())
+            #if canImport(Foundation)
+                self.init(NSNull())
+            #else
+                self.init(Optional<Self>.none)
+            #endif
         } else if let bool = try? container.decode(Bool.self) {
             self.init(bool)
         } else if let int = try? container.decode(Int.self) {
@@ -80,8 +86,10 @@ extension _AnyDecodable {
 extension AnyDecodable: Equatable {
     public static func == (lhs: AnyDecodable, rhs: AnyDecodable) -> Bool {
         switch (lhs.value, rhs.value) {
+#if canImport(Foundation)
         case is (NSNull, NSNull), is (Void, Void):
             return true
+#endif
         case let (lhs as Bool, rhs as Bool):
             return lhs == rhs
         case let (lhs as Int, rhs as Int):

--- a/Sources/AnyCodable/AnyEncodable.swift
+++ b/Sources/AnyCodable/AnyEncodable.swift
@@ -1,4 +1,6 @@
+#if canImport(Foundation)
 import Foundation
+#endif
 
 /**
  A type-erased `Encodable` value.
@@ -56,12 +58,17 @@ extension _AnyEncodable {
         var container = encoder.singleValueContainer()
 
         switch value {
-            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let number as NSNumber:
             try encode(nsnumber: number, into: &container)
-            #endif
+#endif
+#if canImport(Foundation)
         case is NSNull, is Void:
             try container.encodeNil()
+#else
+        case is Void:
+            try container.encodeNil()
+#endif
         case let bool as Bool:
             try container.encode(bool)
         case let int as Int:
@@ -90,10 +97,12 @@ extension _AnyEncodable {
             try container.encode(double)
         case let string as String:
             try container.encode(string)
+#if canImport(Foundation)
         case let date as Date:
             try container.encode(date)
         case let url as URL:
             try container.encode(url)
+#endif
         case let array as [Any?]:
             try container.encode(array.map { AnyCodable($0) })
         case let dictionary as [String: Any?]:

--- a/Sources/AnyCodable/AnyEncodable.swift
+++ b/Sources/AnyCodable/AnyEncodable.swift
@@ -63,12 +63,11 @@ extension _AnyEncodable {
             try encode(nsnumber: number, into: &container)
 #endif
 #if canImport(Foundation)
-        case is NSNull, is Void:
-            try container.encodeNil()
-#else
-        case is Void:
+        case is NSNull:
             try container.encodeNil()
 #endif
+        case is Void:
+            try container.encodeNil()
         case let bool as Bool:
             try container.encode(bool)
         case let int as Int:


### PR DESCRIPTION
Foundation is not available on platforms such as [SwiftWasm](https://swiftwasm.org/), this change allows the library to be compiled for such platforms.