### PR TITLE
Remove build environment information leak with fatalError()

### DIFF
--- a/Sources/AnyCodable/AnyEncodable.swift
+++ b/Sources/AnyCodable/AnyEncodable.swift
@@ -138,8 +138,9 @@ extension _AnyEncodable {
         case .doubleType, .float64Type, .cgFloatType:
             try container.encode(nsnumber.doubleValue)
         #if swift(>=5.0)
-            @unknown default:
-                fatalError()
+        @unknown default:
+            let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "NSNumber cannot be encoded because its type is not handled")
+            throw EncodingError.invalidValue(nsnumber, context)
         #endif
         }
     }


### PR DESCRIPTION
Change fatalError() to preconditionFailure() because the former stores information about the build enviornment in the app binary, even in release builds.
Align the @unknown default case to the other case statements.