### PR TITLE
Library Evolution Support

### DIFF
--- a/AnyCodable.xcodeproj/project.pbxproj
+++ b/AnyCodable.xcodeproj/project.pbxproj
@@ -112,7 +112,7 @@
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -125,7 +125,6 @@
 				OBJ_23 /* README.md */,
 				OBJ_24 /* AnyCodable.xcconfig */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_7 /* Sources */ = {
@@ -214,7 +213,7 @@
 				English,
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_17 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -275,6 +274,7 @@
 		OBJ_27 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
@@ -305,6 +305,7 @@
 		OBJ_28 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
@@ -362,6 +363,7 @@
 		OBJ_36 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				LD = /usr/bin/true;
 				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
 				SWIFT_VERSION = 5.0;
@@ -371,6 +373,7 @@
 		OBJ_37 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				LD = /usr/bin/true;
 				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
 				SWIFT_VERSION = 5.0;
@@ -404,12 +407,14 @@
 		OBJ_42 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 			};
 			name = Debug;
 		};
 		OBJ_43 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 			};
 			name = Release;
 		};

--- a/Sources/AnyCodable/AnyCodable.swift
+++ b/Sources/AnyCodable/AnyCodable.swift
@@ -11,7 +11,7 @@
  - SeeAlso: `AnyEncodable`
  - SeeAlso: `AnyDecodable`
  */
-#if swift(>=5.0)
+#if swift(>=5.1)
 @frozen public struct AnyCodable: Codable {
     public let value: Any
 

--- a/Sources/AnyCodable/AnyCodable.swift
+++ b/Sources/AnyCodable/AnyCodable.swift
@@ -11,7 +11,7 @@
  - SeeAlso: `AnyEncodable`
  - SeeAlso: `AnyDecodable`
  */
-public struct AnyCodable: Codable {
+@frozen public struct AnyCodable: Codable {
     public let value: Any
 
     public init<T>(_ value: T?) {

--- a/Sources/AnyCodable/AnyCodable.swift
+++ b/Sources/AnyCodable/AnyCodable.swift
@@ -11,6 +11,7 @@
  - SeeAlso: `AnyEncodable`
  - SeeAlso: `AnyDecodable`
  */
+#if swift(>=5.0)
 @frozen public struct AnyCodable: Codable {
     public let value: Any
 
@@ -18,6 +19,15 @@
         self.value = value ?? ()
     }
 }
+#else
+public struct AnyCodable: Codable {
+    public let value: Any
+
+    public init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+}
+#endif
 
 extension AnyCodable: _AnyEncodable, _AnyDecodable {}
 

--- a/Sources/AnyCodable/AnyDecodable.swift
+++ b/Sources/AnyCodable/AnyDecodable.swift
@@ -30,7 +30,7 @@ import Foundation
      let decoder = JSONDecoder()
      let dictionary = try! decoder.decode([String: AnyDecodable].self, from: json)
  */
-#if swift(>=5.0)
+#if swift(>=5.1)
 @frozen public struct AnyDecodable: Decodable {
     public let value: Any
 

--- a/Sources/AnyCodable/AnyDecodable.swift
+++ b/Sources/AnyCodable/AnyDecodable.swift
@@ -30,6 +30,7 @@ import Foundation
      let decoder = JSONDecoder()
      let dictionary = try! decoder.decode([String: AnyDecodable].self, from: json)
  */
+#if swift(>=5.0)
 @frozen public struct AnyDecodable: Decodable {
     public let value: Any
 
@@ -37,6 +38,15 @@ import Foundation
         self.value = value ?? ()
     }
 }
+#else
+public struct AnyDecodable: Decodable {
+    public let value: Any
+
+    public init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+}
+#endif
 
 #if swift(>=4.2)
 @usableFromInline

--- a/Sources/AnyCodable/AnyDecodable.swift
+++ b/Sources/AnyCodable/AnyDecodable.swift
@@ -30,7 +30,7 @@ import Foundation
      let decoder = JSONDecoder()
      let dictionary = try! decoder.decode([String: AnyDecodable].self, from: json)
  */
-public struct AnyDecodable: Decodable {
+@frozen public struct AnyDecodable: Decodable {
     public let value: Any
 
     public init<T>(_ value: T?) {

--- a/Sources/AnyCodable/AnyEncodable.swift
+++ b/Sources/AnyCodable/AnyEncodable.swift
@@ -28,7 +28,7 @@ import Foundation
      let encoder = JSONEncoder()
      let json = try! encoder.encode(dictionary)
  */
-public struct AnyEncodable: Encodable {
+@frozen public struct AnyEncodable: Encodable {
     public let value: Any
 
     public init<T>(_ value: T?) {

--- a/Sources/AnyCodable/AnyEncodable.swift
+++ b/Sources/AnyCodable/AnyEncodable.swift
@@ -28,7 +28,7 @@ import Foundation
      let encoder = JSONEncoder()
      let json = try! encoder.encode(dictionary)
  */
-#if swift(>=5.0)
+#if swift(>=5.1)
 @frozen public struct AnyEncodable: Encodable {
     public let value: Any
 

--- a/Sources/AnyCodable/AnyEncodable.swift
+++ b/Sources/AnyCodable/AnyEncodable.swift
@@ -28,6 +28,7 @@ import Foundation
      let encoder = JSONEncoder()
      let json = try! encoder.encode(dictionary)
  */
+#if swift(>=5.0)
 @frozen public struct AnyEncodable: Encodable {
     public let value: Any
 
@@ -35,6 +36,15 @@ import Foundation
         self.value = value ?? ()
     }
 }
+#else
+public struct AnyEncodable: Encodable {
+    public let value: Any
+
+    public init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+}
+#endif
 
 #if swift(>=4.2)
 @usableFromInline


### PR DESCRIPTION
### Overview

Frameworks that support library evolution can have binary compatibility issues when pulling in `AnyCodable`. 

<img width="708" alt="Screen Shot 2020-06-24 at 10 12 03 AM" src="https://user-images.githubusercontent.com/8466790/85618886-72905080-b62f-11ea-8244-830d16be3b44.png">

This work sets `BUILD_LIBRARY_FOR_DISTRIBUTION` to `YES` to enable library evolution support and marks all public structs as `@frozen` to get around [SR-11969](https://bugs.swift.org/browse/SR-11969).

Closes #36 