### PR TITLE
Fix NSNumber encoding on Linux

### DIFF
--- a/Sources/AnyCodable/AnyDecodable.swift
+++ b/Sources/AnyCodable/AnyDecodable.swift
@@ -15,7 +15,7 @@ import Foundation
      let json = """
      {
          "boolean": true,
-         "integer": 42,
+         "integer": 1,
          "double": 3.141592653589793,
          "string": "string",
          "array": [1, 2, 3],

--- a/Sources/AnyCodable/AnyEncodable.swift
+++ b/Sources/AnyCodable/AnyEncodable.swift
@@ -14,7 +14,7 @@ import Foundation
 
      let dictionary: [String: AnyEncodable] = [
          "boolean": true,
-         "integer": 42,
+         "integer": 1,
          "double": 3.141592653589793,
          "string": "string",
          "array": [1, 2, 3],

--- a/Tests/AnyCodableTests/AnyCodableTests.swift
+++ b/Tests/AnyCodableTests/AnyCodableTests.swift
@@ -6,7 +6,7 @@ class AnyCodableTests: XCTestCase {
         let json = """
         {
             "boolean": true,
-            "integer": 42,
+            "integer": 1,
             "double": 3.141592653589793,
             "string": "string",
             "array": [1, 2, 3],
@@ -23,7 +23,7 @@ class AnyCodableTests: XCTestCase {
         let dictionary = try decoder.decode([String: AnyCodable].self, from: json)
 
         XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
-        XCTAssertEqual(dictionary["integer"]?.value as! Int, 42)
+        XCTAssertEqual(dictionary["integer"]?.value as! Int, 1)
         XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
         XCTAssertEqual(dictionary["string"]?.value as! String, "string")
         XCTAssertEqual(dictionary["array"]?.value as! [Int], [1, 2, 3])
@@ -34,7 +34,7 @@ class AnyCodableTests: XCTestCase {
     func testJSONEncoding() throws {
         let dictionary: [String: AnyCodable] = [
             "boolean": true,
-            "integer": 42,
+            "integer": 1,
             "double": 3.141592653589793,
             "string": "string",
             "array": [1, 2, 3],
@@ -54,7 +54,7 @@ class AnyCodableTests: XCTestCase {
         let expected = """
         {
             "boolean": true,
-            "integer": 42,
+            "integer": 1,
             "double": 3.141592653589793,
             "string": "string",
             "array": [1, 2, 3],

--- a/Tests/AnyCodableTests/AnyDecodableTests.swift
+++ b/Tests/AnyCodableTests/AnyDecodableTests.swift
@@ -6,7 +6,7 @@ class AnyDecodableTests: XCTestCase {
         let json = """
         {
             "boolean": true,
-            "integer": 42,
+            "integer": 1,
             "double": 3.141592653589793,
             "string": "string",
             "array": [1, 2, 3],
@@ -23,7 +23,7 @@ class AnyDecodableTests: XCTestCase {
         let dictionary = try decoder.decode([String: AnyDecodable].self, from: json)
 
         XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
-        XCTAssertEqual(dictionary["integer"]?.value as! Int, 42)
+        XCTAssertEqual(dictionary["integer"]?.value as! Int, 1)
         XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
         XCTAssertEqual(dictionary["string"]?.value as! String, "string")
         XCTAssertEqual(dictionary["array"]?.value as! [Int], [1, 2, 3])

--- a/Tests/AnyCodableTests/AnyEncodableTests.swift
+++ b/Tests/AnyCodableTests/AnyEncodableTests.swift
@@ -5,7 +5,7 @@ class AnyEncodableTests: XCTestCase {
     func testJSONEncoding() throws {
         let dictionary: [String: AnyEncodable] = [
             "boolean": true,
-            "integer": 42,
+            "integer": 1,
             "double": 3.141592653589793,
             "string": "string",
             "array": [1, 2, 3],
@@ -25,7 +25,7 @@ class AnyEncodableTests: XCTestCase {
         let expected = """
         {
             "boolean": true,
-            "integer": 42,
+            "integer": 1,
             "double": 3.141592653589793,
             "string": "string",
             "array": [1, 2, 3],
@@ -45,7 +45,7 @@ class AnyEncodableTests: XCTestCase {
     func testEncodeNSNumber() throws {
         let dictionary: [String: NSNumber] = [
             "boolean": true,
-            "integer": 42,
+            "integer": 1,
             "double": 3.141592653589793,
         ]
 
@@ -57,7 +57,7 @@ class AnyEncodableTests: XCTestCase {
         let expected = """
         {
             "boolean": true,
-            "integer": 42,
+            "integer": 1,
             "double": 3.141592653589793,
         }
         """.data(using: .utf8)!
@@ -73,7 +73,7 @@ class AnyEncodableTests: XCTestCase {
     func testStringInterpolationEncoding() throws {
         let dictionary: [String: AnyEncodable] = [
             "boolean": "\(true)",
-            "integer": "\(42)",
+            "integer": "\(1)",
             "double": "\(3.141592653589793)",
             "string": "\("string")",
             "array": "\([1, 2, 3])",
@@ -87,7 +87,7 @@ class AnyEncodableTests: XCTestCase {
         let expected = """
         {
             "boolean": "true",
-            "integer": "42",
+            "integer": "1",
             "double": "3.141592653589793",
             "string": "string",
             "array": "[1, 2, 3]",


### PR DESCRIPTION
This reverts a temporary workaround (b20483678f282fd133d13c2e5dc8e3c71810b3fd) from #43.