### PR TITLE
Fix Xcode warning iOS 8 not supported anymore

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "AnyCodable",
     platforms:  [
-        .iOS(.v8),
+        .iOS(.v9),
         .macOS(.v10_10),
         .tvOS(.v9),
         .watchOS(.v2),


### PR DESCRIPTION
Hi,
First of all, thanks for this nice library 🙂 

When consuming this library via SPM, the Xcode shows the following warning:
`The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.5.99.`.

Since via cocoapods the minimum iOS supported version is 9, and that Xcode 12 doesn't support iOS 8 anymore and show's previous warning, I propose to increate the minimum iOS supported version is 9 on SPM too.

Thanks