### PR TITLE
Add support for encoding any Encodable

### DIFF
--- a/Sources/AnyCodable/AnyEncodable.swift
+++ b/Sources/AnyCodable/AnyEncodable.swift
@@ -98,6 +98,8 @@ extension _AnyEncodable {
             try container.encode(array.map { AnyEncodable($0) })
         case let dictionary as [String: Any?]:
             try container.encode(dictionary.mapValues { AnyEncodable($0) })
+        case let encodable as Encodable:
+            try encodable.encode(to: encoder)
         default:
             let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "AnyEncodable value cannot be encoded")
             throw EncodingError.invalidValue(value, context)

--- a/Tests/AnyCodableTests/AnyCodableTests.swift
+++ b/Tests/AnyCodableTests/AnyCodableTests.swift
@@ -1,6 +1,20 @@
 @testable import AnyCodable
 import XCTest
 
+struct SomeCodable: Codable {
+    var string: String
+    var int: Int
+    var bool: Bool
+    var hasUnderscore: String
+    
+    enum CodingKeys: String,CodingKey {
+        case string
+        case int
+        case bool
+        case hasUnderscore = "has_underscore"
+    }
+}
+
 class AnyCodableTests: XCTestCase {
     func testJSONDecoding() throws {
         let json = """
@@ -18,10 +32,10 @@ class AnyCodableTests: XCTestCase {
             "null": null
         }
         """.data(using: .utf8)!
-
+        
         let decoder = JSONDecoder()
         let dictionary = try decoder.decode([String: AnyCodable].self, from: json)
-
+        
         XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
         XCTAssertEqual(dictionary["integer"]?.value as! Int, 42)
         XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
@@ -30,8 +44,11 @@ class AnyCodableTests: XCTestCase {
         XCTAssertEqual(dictionary["nested"]?.value as! [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
         XCTAssertEqual(dictionary["null"]?.value as! NSNull, NSNull())
     }
-
+    
     func testJSONEncoding() throws {
+        
+        let someCodable = AnyCodable(SomeCodable(string: "String", int: 100, bool: true, hasUnderscore: "another string"))
+        
         let dictionary: [String: AnyCodable] = [
             "boolean": true,
             "integer": 42,
@@ -43,14 +60,15 @@ class AnyCodableTests: XCTestCase {
                 "b": "bravo",
                 "c": "charlie",
             ],
+            "someCodable": someCodable,
             "null": nil
         ]
-
+        
         let encoder = JSONEncoder()
-
+        
         let json = try encoder.encode(dictionary)
         let encodedJSONObject = try JSONSerialization.jsonObject(with: json, options: []) as! NSDictionary
-
+        
         let expected = """
         {
             "boolean": true,
@@ -63,11 +81,17 @@ class AnyCodableTests: XCTestCase {
                 "b": "bravo",
                 "c": "charlie"
             },
+            "someCodable": {
+                "string":"String",
+                "int":100,
+                "bool": true,
+                "has_underscore":"another string"
+            },
             "null": null
         }
         """.data(using: .utf8)!
         let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary
-
+        
         XCTAssertEqual(encodedJSONObject, expectedJSONObject)
     }
 }

--- a/Tests/AnyCodableTests/AnyCodableTests.swift
+++ b/Tests/AnyCodableTests/AnyCodableTests.swift
@@ -1,21 +1,24 @@
 @testable import AnyCodable
 import XCTest
 
-struct SomeCodable: Codable {
-    var string: String
-    var int: Int
-    var bool: Bool
-    var hasUnderscore: String
-    
-    enum CodingKeys: String,CodingKey {
-        case string
-        case int
-        case bool
-        case hasUnderscore = "has_underscore"
-    }
-}
+
 
 class AnyCodableTests: XCTestCase {
+    
+    struct SomeCodable: Codable {
+        var string: String
+        var int: Int
+        var bool: Bool
+        var hasUnderscore: String
+        
+        enum CodingKeys: String,CodingKey {
+            case string
+            case int
+            case bool
+            case hasUnderscore = "has_underscore"
+        }
+    }
+    
     func testJSONDecoding() throws {
         let json = """
         {

--- a/Tests/AnyCodableTests/AnyCodableTests.swift
+++ b/Tests/AnyCodableTests/AnyCodableTests.swift
@@ -32,10 +32,10 @@ class AnyCodableTests: XCTestCase {
             "null": null
         }
         """.data(using: .utf8)!
-        
+
         let decoder = JSONDecoder()
         let dictionary = try decoder.decode([String: AnyCodable].self, from: json)
-        
+
         XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
         XCTAssertEqual(dictionary["integer"]?.value as! Int, 42)
         XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
@@ -44,7 +44,7 @@ class AnyCodableTests: XCTestCase {
         XCTAssertEqual(dictionary["nested"]?.value as! [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
         XCTAssertEqual(dictionary["null"]?.value as! NSNull, NSNull())
     }
-    
+
     func testJSONEncoding() throws {
         
         let someCodable = AnyCodable(SomeCodable(string: "String", int: 100, bool: true, hasUnderscore: "another string"))
@@ -63,12 +63,12 @@ class AnyCodableTests: XCTestCase {
             "someCodable": someCodable,
             "null": nil
         ]
-        
+
         let encoder = JSONEncoder()
-        
+
         let json = try encoder.encode(dictionary)
         let encodedJSONObject = try JSONSerialization.jsonObject(with: json, options: []) as! NSDictionary
-        
+
         let expected = """
         {
             "boolean": true,
@@ -91,7 +91,7 @@ class AnyCodableTests: XCTestCase {
         }
         """.data(using: .utf8)!
         let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary
-        
+
         XCTAssertEqual(encodedJSONObject, expectedJSONObject)
     }
 }

--- a/Tests/AnyCodableTests/AnyEncodableTests.swift
+++ b/Tests/AnyCodableTests/AnyEncodableTests.swift
@@ -2,7 +2,25 @@
 import XCTest
 
 class AnyEncodableTests: XCTestCase {
+    
+    struct SomeEncodable: Encodable {
+        var string: String
+        var int: Int
+        var bool: Bool
+        var hasUnderscore: String
+        
+        enum CodingKeys: String,CodingKey {
+            case string
+            case int
+            case bool
+            case hasUnderscore = "has_underscore"
+        }
+    }
+    
     func testJSONEncoding() throws {
+        
+        let someEncodable = AnyEncodable(SomeEncodable(string: "String", int: 100, bool: true, hasUnderscore: "another string"))
+        
         let dictionary: [String: AnyEncodable] = [
             "boolean": true,
             "integer": 42,
@@ -14,6 +32,7 @@ class AnyEncodableTests: XCTestCase {
                 "b": "bravo",
                 "c": "charlie",
             ],
+            "someCodable": someEncodable,
             "null": nil
         ]
 
@@ -33,6 +52,12 @@ class AnyEncodableTests: XCTestCase {
                 "a": "alpha",
                 "b": "bravo",
                 "c": "charlie"
+            },
+            "someCodable": {
+                "string":"String",
+                "int":100,
+                "bool": true,
+                "has_underscore":"another string"
             },
             "null": null
         }


### PR DESCRIPTION
This PR adds minimal support for encoding any value that conforms to `Encodable` (#58).
Tests have been updated for this case.

What is missing:

Equatable and Hashable support for a wrapped `Codable`
`Decodable` support, however it does not make much sense to decode directly to `AnyCodable` anyway; You would decode the concrete type and then type erase to `AnyCodable` if required.