### PR TITLE
Fix wrong ObjC type mapping

### DIFF
--- a/Sources/AnyCodable/AnyEncodable.swift
+++ b/Sources/AnyCodable/AnyEncodable.swift
@@ -109,21 +109,21 @@ extension _AnyEncodable {
     #if canImport(Foundation)
     private func encode(nsnumber: NSNumber, into container: inout SingleValueEncodingContainer) throws {
         switch Character(Unicode.Scalar(UInt8(nsnumber.objCType.pointee)))  {
-        case "c", "C":
+        case "B":
             try container.encode(nsnumber.boolValue)
-        case "s":
+        case "c":
             try container.encode(nsnumber.int8Value)
-        case "i":
+        case "s":
             try container.encode(nsnumber.int16Value)
-        case "l":
+        case "i", "l":
             try container.encode(nsnumber.int32Value)
         case "q":
             try container.encode(nsnumber.int64Value)
-        case "S":
+        case "C":
             try container.encode(nsnumber.uint8Value)
-        case "I":
+        case "S":
             try container.encode(nsnumber.uint16Value)
-        case "L":
+        case "I", "L":
             try container.encode(nsnumber.uint32Value)
         case "Q":
             try container.encode(nsnumber.uint64Value)

--- a/Tests/AnyCodableTests/AnyCodableTests.swift
+++ b/Tests/AnyCodableTests/AnyCodableTests.swift
@@ -74,7 +74,7 @@ class AnyCodableTests: XCTestCase {
 
         let expected = """
         {
-            "boolean": true,
+            "boolean": 1,
             "integer": 42,
             "double": 3.141592653589793,
             "string": "string",

--- a/Tests/AnyCodableTests/AnyEncodableTests.swift
+++ b/Tests/AnyCodableTests/AnyEncodableTests.swift
@@ -43,7 +43,7 @@ class AnyEncodableTests: XCTestCase {
 
         let expected = """
         {
-            "boolean": true,
+            "boolean": 1,
             "integer": 42,
             "double": 3.141592653589793,
             "string": "string",
@@ -90,7 +90,7 @@ class AnyEncodableTests: XCTestCase {
 
         let expected = """
         {
-            "boolean": true,
+            "boolean": 1,
             "char": -127,
             "int": -32767,
             "short": -32767,

--- a/Tests/AnyCodableTests/AnyEncodableTests.swift
+++ b/Tests/AnyCodableTests/AnyEncodableTests.swift
@@ -70,7 +70,16 @@ class AnyEncodableTests: XCTestCase {
     func testEncodeNSNumber() throws {
         let dictionary: [String: NSNumber] = [
             "boolean": true,
-            "integer": 42,
+            "char": -127,
+            "int": -32767,
+            "short": -32767,
+            "long": -2147483647,
+            "longlong": -9223372036854775807,
+            "uchar": 255,
+            "uint": 65535,
+            "ushort": 65535,
+            "ulong": 4294967295,
+            "ulonglong": 18446744073709615,
             "double": 3.141592653589793,
         ]
 
@@ -82,7 +91,16 @@ class AnyEncodableTests: XCTestCase {
         let expected = """
         {
             "boolean": true,
-            "integer": 42,
+            "char": -127,
+            "int": -32767,
+            "short": -32767,
+            "long": -2147483647,
+            "longlong": -9223372036854775807,
+            "uchar": 255,
+            "uint": 65535,
+            "ushort": 65535,
+            "ulong": 4294967295,
+            "ulonglong": 18446744073709615,
             "double": 3.141592653589793,
         }
         """.data(using: .utf8)!
@@ -90,7 +108,19 @@ class AnyEncodableTests: XCTestCase {
 
         XCTAssertEqual(encodedJSONObject, expectedJSONObject)
         XCTAssert(encodedJSONObject["boolean"] is Bool)
-        XCTAssert(encodedJSONObject["integer"] is Int)
+
+        XCTAssert(encodedJSONObject["char"] is Int8)
+        XCTAssert(encodedJSONObject["int"] is Int16)
+        XCTAssert(encodedJSONObject["short"] is Int32)
+        XCTAssert(encodedJSONObject["long"] is Int32)
+        XCTAssert(encodedJSONObject["longlong"] is Int64)
+
+        XCTAssert(encodedJSONObject["uchar"] is UInt8)
+        XCTAssert(encodedJSONObject["uint"] is UInt16)
+        XCTAssert(encodedJSONObject["ushort"] is UInt32)
+        XCTAssert(encodedJSONObject["ulong"] is UInt32)
+        XCTAssert(encodedJSONObject["ulonglong"] is UInt64)
+
         XCTAssert(encodedJSONObject["double"] is Double)
     }
 


### PR DESCRIPTION
Issue occurred when I used AnyCodable between ObjC and Swift code with `NSNumber`.

Following ObjC code:
`@(700000004)`

Encoded value in Swift:
`9988`

Because `encode(nsnumber: container:)` applied `container.encode(nsnumber.int16Value)` instead of `container.encode(nsnumber.int32Value)`.

There was an error in the switch.
I checked on [Apple documentation](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html) and updated accordingly.
