### PR TITLE
Adding missing string interpolation handling for AnyCodable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ DeriveredData/
 /*.gcno
 **/xcshareddata/WorkspaceSettings.xcsettings
 Carthage/Build/
+/.swiftpm

--- a/Sources/AnyCodable/AnyCodable.swift
+++ b/Sources/AnyCodable/AnyCodable.swift
@@ -100,6 +100,7 @@ extension AnyCodable: ExpressibleByBooleanLiteral {}
 extension AnyCodable: ExpressibleByIntegerLiteral {}
 extension AnyCodable: ExpressibleByFloatLiteral {}
 extension AnyCodable: ExpressibleByStringLiteral {}
+extension AnyCodable: ExpressibleByStringInterpolation {}
 extension AnyCodable: ExpressibleByArrayLiteral {}
 extension AnyCodable: ExpressibleByDictionaryLiteral {}
 

--- a/Tests/AnyCodableTests/AnyCodableTests.swift
+++ b/Tests/AnyCodableTests/AnyCodableTests.swift
@@ -81,12 +81,14 @@ class AnyCodableTests: XCTestCase {
     func testJSONEncoding() throws {
         
         let someCodable = AnyCodable(SomeCodable(string: "String", int: 100, bool: true, hasUnderscore: "another string"))
-        
+
+        let injectedValue = 1234
         let dictionary: [String: AnyCodable] = [
             "boolean": true,
             "integer": 42,
             "double": 3.141592653589793,
             "string": "string",
+            "stringInterpolation": "string \(injectedValue)",
             "array": [1, 2, 3],
             "nested": [
                 "a": "alpha",
@@ -108,6 +110,7 @@ class AnyCodableTests: XCTestCase {
             "integer": 42,
             "double": 3.141592653589793,
             "string": "string",
+            "stringInterpolation": "string 1234",
             "array": [1, 2, 3],
             "nested": {
                 "a": "alpha",


### PR DESCRIPTION
This adds `ExpressibleByStringInterpolation` to `AnyCodable` so that this will work:

```swift
let value = 1234
let result: AnyCodable = "abcd \(value)"
```

Without it the second line will not compile.