### PR TITLE
Improve tests and fix encoding of NSNumber

### DIFF
--- a/Sources/AnyCodable/AnyEncodable.swift
+++ b/Sources/AnyCodable/AnyEncodable.swift
@@ -55,6 +55,8 @@ extension _AnyEncodable {
         #if canImport(Foundation)
         case is NSNull:
             try container.encodeNil()
+        case let number as NSNumber:
+            try encode(nsnumber: number, into: &container)
         #endif
         case is Void:
             try container.encodeNil()
@@ -87,8 +89,6 @@ extension _AnyEncodable {
         case let string as String:
             try container.encode(string)
         #if canImport(Foundation)
-        case let number as NSNumber:
-            try encode(nsnumber: number, into: &container)
         case let date as Date:
             try container.encode(date)
         case let url as URL:
@@ -112,7 +112,7 @@ extension _AnyEncodable {
         case "B":
             try container.encode(nsnumber.boolValue)
         case "c":
-            try container.encode(nsnumber.int8Value)
+            try container.encode(nsnumber.boolValue)
         case "s":
             try container.encode(nsnumber.int16Value)
         case "i", "l":
@@ -120,7 +120,7 @@ extension _AnyEncodable {
         case "q":
             try container.encode(nsnumber.int64Value)
         case "C":
-            try container.encode(nsnumber.uint8Value)
+            try container.encode(nsnumber.boolValue)
         case "S":
             try container.encode(nsnumber.uint16Value)
         case "I", "L":

--- a/Sources/AnyCodable/AnyEncodable.swift
+++ b/Sources/AnyCodable/AnyEncodable.swift
@@ -108,28 +108,24 @@ extension _AnyEncodable {
 
     #if canImport(Foundation)
     private func encode(nsnumber: NSNumber, into container: inout SingleValueEncodingContainer) throws {
-        switch Character(Unicode.Scalar(UInt8(nsnumber.objCType.pointee)))  {
-        case "B":
+        switch UInt32(nsnumber.objCType.pointee)  {
+        case cpp_or_c99_bool_objc_encoding, char_objc_encoding, unsigned_char_objc_encoding:
             try container.encode(nsnumber.boolValue)
-        case "c":
-            try container.encode(nsnumber.boolValue)
-        case "s":
+        case short_objc_encoding:
             try container.encode(nsnumber.int16Value)
-        case "i", "l":
+        case int_objc_encoding, long_objc_encoding:
             try container.encode(nsnumber.int32Value)
-        case "q":
+        case long_long_objc_encoding:
             try container.encode(nsnumber.int64Value)
-        case "C":
-            try container.encode(nsnumber.boolValue)
-        case "S":
+        case unsigned_short_objc_encoding:
             try container.encode(nsnumber.uint16Value)
-        case "I", "L":
+        case unsigned_int_objc_encoding, unsigned_long_objc_encoding:
             try container.encode(nsnumber.uint32Value)
-        case "Q":
+        case unsigned_long_long_objc_encoding:
             try container.encode(nsnumber.uint64Value)
-        case "f":
+        case float_objc_encoding:
             try container.encode(nsnumber.floatValue)
-        case "d":
+        case double_objc_encoding:
             try container.encode(nsnumber.doubleValue)
         default:
             let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "NSNumber cannot be encoded because its type is not handled")
@@ -289,3 +285,21 @@ extension AnyEncodable: Hashable {
         }
     }
 }
+
+
+#if canImport(Foundation)
+  // Types encodings: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
+  private let cpp_or_c99_bool_objc_encoding = "B".unicodeScalars.first?.value
+  private let char_objc_encoding = "c".unicodeScalars.first?.value
+  private let short_objc_encoding = "s".unicodeScalars.first?.value
+  private let int_objc_encoding = "i".unicodeScalars.first?.value
+  private let long_objc_encoding = "l".unicodeScalars.first?.value
+  private let long_long_objc_encoding = "q".unicodeScalars.first?.value
+  private let unsigned_char_objc_encoding = "C".unicodeScalars.first?.value
+  private let unsigned_short_objc_encoding = "S".unicodeScalars.first?.value
+  private let unsigned_int_objc_encoding = "I".unicodeScalars.first?.value
+  private let unsigned_long_objc_encoding = "L".unicodeScalars.first?.value
+  private let unsigned_long_long_objc_encoding = "Q".unicodeScalars.first?.value
+  private let float_objc_encoding = "f".unicodeScalars.first?.value
+  private let double_objc_encoding = "d".unicodeScalars.first?.value
+#endif

--- a/Tests/AnyCodableTests/AnyCodableTests.swift
+++ b/Tests/AnyCodableTests/AnyCodableTests.swift
@@ -39,13 +39,13 @@ class AnyCodableTests: XCTestCase {
         let decoder = JSONDecoder()
         let dictionary = try decoder.decode([String: AnyCodable].self, from: json)
 
-        XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
-        XCTAssertEqual(dictionary["integer"]?.value as! Int, 42)
-        XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
-        XCTAssertEqual(dictionary["string"]?.value as! String, "string")
-        XCTAssertEqual(dictionary["array"]?.value as! [Int], [1, 2, 3])
-        XCTAssertEqual(dictionary["nested"]?.value as! [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
-        XCTAssertEqual(dictionary["null"]?.value as! NSNull, NSNull())
+        XCTAssertEqual(dictionary["boolean"]?.value as? Bool, true)
+        XCTAssertEqual(dictionary["integer"]?.value as? Int, 42)
+        XCTAssertEqual(try XCTUnwrap(dictionary["double"]?.value as? Double), 3.141592653589793, accuracy: 0.001)
+        XCTAssertEqual(dictionary["string"]?.value as? String, "string")
+        XCTAssertEqual(dictionary["array"]?.value as? [Int], [1, 2, 3])
+        XCTAssertEqual(dictionary["nested"]?.value as? [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
+        XCTAssertEqual(dictionary["null"]?.value as? NSNull, NSNull())
     }
 
     func testJSONDecodingEquatable() throws {
@@ -102,7 +102,6 @@ class AnyCodableTests: XCTestCase {
         let encoder = JSONEncoder()
 
         let json = try encoder.encode(dictionary)
-        let encodedJSONObject = try JSONSerialization.jsonObject(with: json, options: []) as! NSDictionary
 
         let expected = """
         {
@@ -125,9 +124,7 @@ class AnyCodableTests: XCTestCase {
             },
             "null": null
         }
-        """.data(using: .utf8)!
-        let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary
-
-        XCTAssertEqual(encodedJSONObject, expectedJSONObject)
+        """
+        try XCTAssertJsonAreIdentical(json, expected)
     }
 }

--- a/Tests/AnyCodableTests/AnyDecodableTests.swift
+++ b/Tests/AnyCodableTests/AnyDecodableTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class AnyDecodableTests: XCTestCase {
     func testJSONDecoding() throws {
-        let json = """
+        let json = try XCTUnwrap("""
         {
             "boolean": true,
             "integer": 42,
@@ -17,17 +17,17 @@ class AnyDecodableTests: XCTestCase {
             },
             "null": null
         }
-        """.data(using: .utf8)!
+        """.data(using: .utf8))
 
         let decoder = JSONDecoder()
         let dictionary = try decoder.decode([String: AnyDecodable].self, from: json)
 
-        XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
-        XCTAssertEqual(dictionary["integer"]?.value as! Int, 42)
-        XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
-        XCTAssertEqual(dictionary["string"]?.value as! String, "string")
-        XCTAssertEqual(dictionary["array"]?.value as! [Int], [1, 2, 3])
-        XCTAssertEqual(dictionary["nested"]?.value as! [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
-        XCTAssertEqual(dictionary["null"]?.value as! NSNull, NSNull())
+        XCTAssertEqual(dictionary["boolean"]?.value as? Bool, true)
+        XCTAssertEqual(dictionary["integer"]?.value as? Int, 42)
+        XCTAssertEqual(try XCTUnwrap(dictionary["double"]?.value as? Double), 3.141592653589793, accuracy: 0.001)
+        XCTAssertEqual(dictionary["string"]?.value as? String, "string")
+        XCTAssertEqual(dictionary["array"]?.value as? [Int], [1, 2, 3])
+        XCTAssertEqual(dictionary["nested"]?.value as? [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
+        XCTAssertEqual(dictionary["null"]?.value as? NSNull, NSNull())
     }
 }


### PR DESCRIPTION
## Changes
- Improve tests
   - Some minor changes to remove force unwrapping in tests.
   - Existing encoding tests validate that deserialized serialized value is equal to some value. This is different than directly asserting that the serialized value is as expected, and it lets some errors go unnoticed as equality on `NSDictionary` is very permissive. For instance this test will pass:
```swift
let dictionary: [String: AnyEncodable] = ["k": true]
let json = try JSONEncoder().encode(dictionary)
let encodedJSONObject = try JSONSerialization.jsonObject(with: json, options: []) as! NSDictionary

let expected = "{ \"k\": 1 }".data(using: .utf8)!
let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary

XCTAssertEqual(encodedJSONObject, expectedJSONObject)
```
Instead if we compare the serialized value (`{ "k": true }`) to that of the expectation (`{ "k": 1 }`) this test will logically fail.
I added util function to ease the comparison of serialized JSON strings.

- Fix serialization of `NSNumber`. There were two issues:
    - We test for `as? Bool` before testing `as? NSNumber`. A `NSNumber` can always be casted as a `Bool` so the later case was never hit
    - `Swift.Bool` are represented as a char type in ObjC and the mapping was incorrect
    - Add a test for `NSNumber`'s serialization.
- Nit: reduce runtime computations when encoding `NSNumber`, which after this fix might be more frequent